### PR TITLE
fix(build): Build against the included `zlib`.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,10 +11,6 @@ environment:
     - nodejs_version: 10
     - nodejs_version: 11
 
-matrix:
-  allow_failures:
-    - nodejs_version: 6
-
 install:
   - ps: Install-Product node $env:nodejs_version
   - npm install -g npm

--- a/src/decoder/pnglibconf.h
+++ b/src/decoder/pnglibconf.h
@@ -13,7 +13,6 @@
 /* Derived from: scripts/pnglibconf.dfa */
 #ifndef PNGLCONF_H
 #define PNGLCONF_H
-#include <node_version.h>
 /* options */
 #define PNG_16BIT_SUPPORTED
 #define PNG_ALIGNED_MEMORY_SUPPORTED
@@ -161,11 +160,7 @@
 #define PNG_USER_WIDTH_MAX 1000000
 #define PNG_WEIGHT_SHIFT 8
 #define PNG_ZBUF_SIZE 8192
-#if NODE_VERSION_AT_LEAST(8, 0, 0)
 #define PNG_ZLIB_VERNUM 0x12b0
-#else
-#define PNG_ZLIB_VERNUM 0x1280
-#endif
 #define PNG_Z_DEFAULT_COMPRESSION (-1)
 #define PNG_Z_DEFAULT_NOFILTER_STRATEGY 0
 #define PNG_Z_DEFAULT_STRATEGY 1

--- a/src/encoder/pnglibconf.h
+++ b/src/encoder/pnglibconf.h
@@ -13,7 +13,6 @@
 /* Derived from: scripts/pnglibconf.dfa */
 #ifndef PNGLCONF_H
 #define PNGLCONF_H
-#include <node_version.h>
 /* options */
 #define PNG_16BIT_SUPPORTED
 #define PNG_ALIGNED_MEMORY_SUPPORTED
@@ -152,11 +151,7 @@
 #define PNG_USER_WIDTH_MAX 1000000
 #define PNG_WEIGHT_SHIFT 8
 #define PNG_ZBUF_SIZE 8192
-#if NODE_VERSION_AT_LEAST(8, 0, 0)
 #define PNG_ZLIB_VERNUM 0x12b0
-#else
-#define PNG_ZLIB_VERNUM 0x1280
-#endif
 #define PNG_Z_DEFAULT_COMPRESSION (-1)
 #define PNG_Z_DEFAULT_NOFILTER_STRATEGY 0
 #define PNG_Z_DEFAULT_STRATEGY 1


### PR DESCRIPTION
This really just reverts 84ff31d – I'm a little confused why that was even required in the first place.