### PR TITLE
fix(build): Always build _everything_ from source.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,11 +22,6 @@ matrix:
       os: windows
     - node_js: 11
       os: windows
-addons:
-  apt:
-    packages:
-      - libgif-dev
-      - libpng16-dev
 env:
   global:
     - secure: m6GYIw709a4vzQQaUn995+d5xg7OhjRl6ynSZj/ih0mZkhmXoXC0tgixyLyaqova3qMZ1JXKlRRRwW5RMIGFQkPCdlhhuQ6Ou85HCyDXqbxHi5uhLbE4MgkAcEZ2N+k5IxLZOarWT2bUasCSDSiIQnxC/UbRkqL9r3ZhDyjWzpK8j06BXyP/NfHO486K4bsd+6hb++6vyvBAzhT0rbCUayAWXpA+E8J7qAE3VaKIPTfzdDL1jA8KJojmL6GaMHA6e1/SlPlK4q2IRx6byXW7scB6/95eT6ETYKTeWtVN4LhprunHeAF+wvlmJ1wFJwY4Ku9hDXEmaES9FYDaaujb+DQDApS8y/u/uaui+hn3vDnJenL2rnGO72bV0AytB4DdsQa9pM2R6xrY8qr0kc+I/rxNtUOEG/iNgXMTOJwIftPrUl0zVvxERuMtX9CiNYNIobzJfOYWlW5MSs3T1E39qvrtIimUu2S+AN09TGO9hhL3J648xEk3bWZ6mV0F9sZal3/wuS8TzZ2ezlCwjEojDuuOBTGoOI1VRWv3+elYR8FrGt6eca1znZMCHX8lrbAA3xb0dqAQHuYZ0pwBhVikOsguNCnipdii0vU6uQKejw+uD4SbdfnZ/Uh1wABynhISWx/1wJwtICk4NabEGAt9A7GjkGT5M/f7EmQpks8l4eE=
@@ -38,9 +33,6 @@ node_js:
   - 10
   - 11
 cache: npm
-before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt autoremove; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get remove libjpeg-turbo8-dev libjpeg9-dev+; fi
 install: >-
   if [[ "$TRAVIS_OS_NAME" == "windows" && "$TRAVIS_NODE_VERSION" == "6" ]];
     then npm install --msvs_version=$MSVS_VERSION;

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
       node_js: 6
       os: windows
       env:
-        - MSVS_VERSION=2015
+        - GYP_MSVS_VERSION=2015
   allow_failures:
     - *node6
     - node_js: 8
@@ -33,11 +33,6 @@ node_js:
   - 10
   - 11
 cache: npm
-install: >-
-  if [[ "$TRAVIS_OS_NAME" == "windows" && "$TRAVIS_NODE_VERSION" == "6" ]];
-    then npm install --msvs_version=$MSVS_VERSION;
-    else npm install;
-  fi;
 before_script:
   - npm run pretest
   - >-

--- a/README.md
+++ b/README.md
@@ -90,8 +90,6 @@ If `npm install @randy.tarampi/lwip` fails, you probably need to setup your syst
 
 See the [instructions for `node-gyp`](https://github.com/TooTallNate/node-gyp#installation).
 
-Building on non-Windows systems requires that you have `giflib`, `libjpeg` and `libpng` already installed and available.
-
 Building on Windows with Visual Studio requires version 2013 or higher.
 
 ### Usage

--- a/binding.gyp
+++ b/binding.gyp
@@ -10,46 +10,94 @@
             "src/decoder/jpeg_decoder.cpp",
             "src/decoder/png_decoder.cpp",
             "src/decoder/gif_decoder.cpp",
+            # LIB JPEG:
+            ###########
+            "src/lib/jpeg/jmemnobs.c",
+            "src/lib/jpeg/jcomapi.c",
+            "src/lib/jpeg/jdapimin.c",
+            "src/lib/jpeg/jdapistd.c",
+            "src/lib/jpeg/jdatadst.c",
+            "src/lib/jpeg/jdatasrc.c",
+            "src/lib/jpeg/jdcoefct.c",
+            "src/lib/jpeg/jdcolor.c",
+            "src/lib/jpeg/jddctmgr.c",
+            "src/lib/jpeg/jdhuff.c",
+            "src/lib/jpeg/jdinput.c",
+            "src/lib/jpeg/jdmainct.c",
+            "src/lib/jpeg/jdmarker.c",
+            "src/lib/jpeg/jdmaster.c",
+            "src/lib/jpeg/jdpostct.c",
+            "src/lib/jpeg/jdsample.c",
+            "src/lib/jpeg/jerror.c",
+            "src/lib/jpeg/jfdctflt.c",
+            "src/lib/jpeg/jfdctfst.c",
+            "src/lib/jpeg/jfdctint.c",
+            "src/lib/jpeg/jidctflt.c",
+            "src/lib/jpeg/jidctfst.c",
+            "src/lib/jpeg/jidctint.c",
+            "src/lib/jpeg/jutils.c",
+            "src/lib/jpeg/jmemmgr.c",
+            "src/lib/jpeg/jdarith.c",
+            "src/lib/jpeg/jdmerge.c",
+            "src/lib/jpeg/jaricom.c",
+            "src/lib/jpeg/jquant1.c",
+            "src/lib/jpeg/jquant2.c",
+            # LIB PNG:
+            ##########
+            "src/lib/png/png.c",
+            "src/lib/png/pngset.c",
+            "src/lib/png/pngget.c",
+            "src/lib/png/pngrutil.c",
+            "src/lib/png/pngtrans.c",
+            "src/lib/png/pngread.c",
+            "src/lib/png/pngwrite.c",
+            "src/lib/png/pngrio.c",
+            "src/lib/png/pngrtran.c",
+            "src/lib/png/pngmem.c",
+            "src/lib/png/pngerror.c",
+            "src/lib/png/pngpread.c",
+            # ZLIB:
+            #######
+            "src/lib/zlib/adler32.c",
+            "src/lib/zlib/crc32.c",
+            "src/lib/zlib/gzlib.c",
+            "src/lib/zlib/gzread.c",
+            "src/lib/zlib/infback.c",
+            "src/lib/zlib/inflate.c",
+            "src/lib/zlib/inftrees.c",
+            "src/lib/zlib/inffast.c",
+            "src/lib/zlib/uncompr.c",
+            "src/lib/zlib/zutil.c",
+            "src/lib/zlib/trees.c",
+            # LIB GIF:
+            ##########
+            "src/lib/gif/dgif_lib.c",
+            "src/lib/gif/gif_err.c",
+            "src/lib/gif/gifalloc.c",
+            "src/lib/gif/openbsd-reallocarray.c",
         ],
         'include_dirs': [
             '<!(node -e "require(\'nan\')")',
             'src/decoder',
             'src/shared',
+            'src/lib/zlib',
+            'src/lib/jpeg',
             'src/lib/cimg',
+            'src/lib/png',
+            'src/lib/gif'
         ],
         'conditions': [
             ['OS=="freebsd"', {
                 'cflags!': ['-fno-exceptions'],
                 'cflags_cc!': ['-fno-exceptions'],
-                'link_settings': {
-                    'libraries': [
-                        '-lpng',
-                        '-ljpeg',
-                        '-lgif',
-                    ],
-                },
             }],
             ['OS=="solaris"', {
                 'cflags!': ['-fno-exceptions'],
                 'cflags_cc!': ['-fno-exceptions'],
-                'link_settings': {
-                    'libraries': [
-                        '-lpng',
-                        '-ljpeg',
-                        '-lgif',
-                    ],
-                },
             }],
             ['OS=="linux"', {
                 'cflags!': ['-fno-exceptions'],
                 'cflags_cc!': ['-fno-exceptions'],
-                'link_settings': {
-                    'libraries': [
-                        '-lpng',
-                        '-ljpeg',
-                        '-lgif',
-                    ],
-                },
             }],
             ['OS=="mac"', {
                 'xcode_settings': {
@@ -58,14 +106,7 @@
                           '-stdlib=libc++',
                           '-std=c++0x']
                 },
-                'include_dirs': ['/usr/include/malloc'],
-                'link_settings': {
-                    'libraries': [
-                        '-lpng',
-                        '-ljpeg',
-                        '-lgif',
-                    ],
-                },
+                'include_dirs': ['/usr/include/malloc']
             }],
             ['OS=="win"', {
                 'configurations': {
@@ -77,81 +118,7 @@
                         }
                     }
                 },
-                'sources': [
-                    # LIB JPEG:
-                    ###########
-                    "src/lib/jpeg/jmemnobs.c",
-                    "src/lib/jpeg/jcomapi.c",
-                    "src/lib/jpeg/jdapimin.c",
-                    "src/lib/jpeg/jdapistd.c",
-                    "src/lib/jpeg/jdatadst.c",
-                    "src/lib/jpeg/jdatasrc.c",
-                    "src/lib/jpeg/jdcoefct.c",
-                    "src/lib/jpeg/jdcolor.c",
-                    "src/lib/jpeg/jddctmgr.c",
-                    "src/lib/jpeg/jdhuff.c",
-                    "src/lib/jpeg/jdinput.c",
-                    "src/lib/jpeg/jdmainct.c",
-                    "src/lib/jpeg/jdmarker.c",
-                    "src/lib/jpeg/jdmaster.c",
-                    "src/lib/jpeg/jdpostct.c",
-                    "src/lib/jpeg/jdsample.c",
-                    "src/lib/jpeg/jerror.c",
-                    "src/lib/jpeg/jfdctflt.c",
-                    "src/lib/jpeg/jfdctfst.c",
-                    "src/lib/jpeg/jfdctint.c",
-                    "src/lib/jpeg/jidctflt.c",
-                    "src/lib/jpeg/jidctfst.c",
-                    "src/lib/jpeg/jidctint.c",
-                    "src/lib/jpeg/jutils.c",
-                    "src/lib/jpeg/jmemmgr.c",
-                    "src/lib/jpeg/jdarith.c",
-                    "src/lib/jpeg/jdmerge.c",
-                    "src/lib/jpeg/jaricom.c",
-                    "src/lib/jpeg/jquant1.c",
-                    "src/lib/jpeg/jquant2.c",
-                    # LIB PNG:
-                    ##########
-                    "src/lib/png/png.c",
-                    "src/lib/png/pngset.c",
-                    "src/lib/png/pngget.c",
-                    "src/lib/png/pngrutil.c",
-                    "src/lib/png/pngtrans.c",
-                    "src/lib/png/pngread.c",
-                    "src/lib/png/pngwutil.c",
-                    "src/lib/png/pngwrite.c",
-                    "src/lib/png/pngrio.c",
-                    "src/lib/png/pngrtran.c",
-                    "src/lib/png/pngmem.c",
-                    "src/lib/png/pngerror.c",
-                    "src/lib/png/pngpread.c",
-                    # ZLIB:
-                    #######
-                    "src/lib/zlib/adler32.c",
-                    "src/lib/zlib/crc32.c",
-                    "src/lib/zlib/gzlib.c",
-                    "src/lib/zlib/gzread.c",
-                    "src/lib/zlib/infback.c",
-                    "src/lib/zlib/inflate.c",
-                    "src/lib/zlib/inftrees.c",
-                    "src/lib/zlib/inffast.c",
-                    "src/lib/zlib/uncompr.c",
-                    "src/lib/zlib/zutil.c",
-                    "src/lib/zlib/trees.c",
-                    # LIB GIF:
-                    ##########
-                    "src/lib/gif/dgif_lib.c",
-                    "src/lib/gif/gif_err.c",
-                    "src/lib/gif/gifalloc.c",
-                    "src/lib/gif/openbsd-reallocarray.c",
-                ],
-                'include_dirs': [
-                    'src/win',
-                    'src/lib/zlib',
-                    'src/lib/jpeg',
-                    'src/lib/png',
-                    'src/lib/gif',
-                ]
+                'include_dirs': ['src/win']
             }]
         ]
     },{
@@ -163,46 +130,91 @@
             "src/encoder/jpeg_worker.cpp",
             "src/encoder/png_worker.cpp",
             "src/encoder/gif_worker.cpp",
+            # LIB JPEG:
+            ###########
+            "src/lib/jpeg/jdatadst.c",
+            "src/lib/jpeg/jmemnobs.c",
+            "src/lib/jpeg/jcomapi.c",
+            "src/lib/jpeg/jerror.c",
+            "src/lib/jpeg/jfdctflt.c",
+            "src/lib/jpeg/jfdctfst.c",
+            "src/lib/jpeg/jfdctint.c",
+            "src/lib/jpeg/jidctflt.c",
+            "src/lib/jpeg/jidctfst.c",
+            "src/lib/jpeg/jidctint.c",
+            "src/lib/jpeg/jutils.c",
+            "src/lib/jpeg/jmemmgr.c",
+            "src/lib/jpeg/jaricom.c",
+            "src/lib/jpeg/jquant1.c",
+            "src/lib/jpeg/jquant2.c",
+            "src/lib/jpeg/jcapimin.c",
+            "src/lib/jpeg/jcapistd.c",
+            "src/lib/jpeg/jccoefct.c",
+            "src/lib/jpeg/jccolor.c",
+            "src/lib/jpeg/jcdctmgr.c",
+            "src/lib/jpeg/jchuff.c",
+            "src/lib/jpeg/jcinit.c",
+            "src/lib/jpeg/jcmainct.c",
+            "src/lib/jpeg/jcmarker.c",
+            "src/lib/jpeg/jcmaster.c",
+            "src/lib/jpeg/jcparam.c",
+            "src/lib/jpeg/jcprepct.c",
+            "src/lib/jpeg/jcsample.c",
+            "src/lib/jpeg/jcarith.c",
+            # LIB PNG:
+            ##########
+            "src/lib/png/png.c",
+            "src/lib/png/pngset.c",
+            "src/lib/png/pngget.c",
+            "src/lib/png/pngtrans.c",
+            "src/lib/png/pngmem.c",
+            "src/lib/png/pngerror.c",
+            "src/lib/png/pngread.c",
+            "src/lib/png/pngwrite.c",
+            "src/lib/png/pngwutil.c",
+            "src/lib/png/pngwio.c",
+            "src/lib/png/pngwtran.c",
+            # ZLIB:
+            #######
+            "src/lib/zlib/adler32.c",
+            "src/lib/zlib/crc32.c",
+            "src/lib/zlib/gzlib.c",
+            "src/lib/zlib/zutil.c",
+            "src/lib/zlib/gzwrite.c",
+            "src/lib/zlib/compress.c",
+            "src/lib/zlib/deflate.c",
+            "src/lib/zlib/trees.c",
+            # LIB GIF:
+            ##########
+            "src/lib/gif/egif_lib.c",
+            "src/lib/gif/gif_err.c",
+            "src/lib/gif/gifalloc.c",
+            "src/lib/gif/gif_hash.c",
+            "src/lib/gif/quantize.c",
+            "src/lib/gif/openbsd-reallocarray.c",
         ],
         'include_dirs': [
             '<!(node -e "require(\'nan\')")',
             'src/encoder',
             'src/shared',
+            'src/lib/zlib',
+            'src/lib/jpeg',
             'src/lib/cimg',
+            'src/lib/png',
+            'src/lib/gif'
         ],
         'conditions': [
             ['OS=="freebsd"', {
                 'cflags!': ['-fno-exceptions'],
                 'cflags_cc!': ['-fno-exceptions'],
-                'link_settings': {
-                    'libraries': [
-                        '-lpng',
-                        '-ljpeg',
-                        '-lgif',
-                    ],
-                },
             }],
             ['OS=="solaris"', {
                 'cflags!': ['-fno-exceptions'],
                 'cflags_cc!': ['-fno-exceptions'],
-                'link_settings': {
-                    'libraries': [
-                        '-lpng',
-                        '-ljpeg',
-                        '-lgif',
-                    ],
-                },
             }],
             ['OS=="linux"', {
                 'cflags!': ['-fno-exceptions'],
                 'cflags_cc!': ['-fno-exceptions'],
-                'link_settings': {
-                    'libraries': [
-                        '-lpng',
-                        '-ljpeg',
-                        '-lgif',
-                    ],
-                },
             }],
             ['OS=="mac"', {
                 'xcode_settings': {
@@ -211,14 +223,7 @@
                           '-stdlib=libc++',
                           '-std=c++0x']
                 },
-                'include_dirs': ['/usr/include/malloc'],
-                'link_settings': {
-                    'libraries': [
-                        '-lpng',
-                        '-ljpeg',
-                        '-lgif',
-                    ],
-                },
+                'include_dirs': ['/usr/include/malloc']
             }],
             ['OS=="win"', {
                 'configurations': {
@@ -230,77 +235,7 @@
                         }
                     }
                 },
-                'sources': [
-                    # LIB JPEG:
-                    ###########
-                    "src/lib/jpeg/jdatadst.c",
-                    "src/lib/jpeg/jmemnobs.c",
-                    "src/lib/jpeg/jcomapi.c",
-                    "src/lib/jpeg/jerror.c",
-                    "src/lib/jpeg/jfdctflt.c",
-                    "src/lib/jpeg/jfdctfst.c",
-                    "src/lib/jpeg/jfdctint.c",
-                    "src/lib/jpeg/jidctflt.c",
-                    "src/lib/jpeg/jidctfst.c",
-                    "src/lib/jpeg/jidctint.c",
-                    "src/lib/jpeg/jutils.c",
-                    "src/lib/jpeg/jmemmgr.c",
-                    "src/lib/jpeg/jaricom.c",
-                    "src/lib/jpeg/jquant1.c",
-                    "src/lib/jpeg/jquant2.c",
-                    "src/lib/jpeg/jcapimin.c",
-                    "src/lib/jpeg/jcapistd.c",
-                    "src/lib/jpeg/jccoefct.c",
-                    "src/lib/jpeg/jccolor.c",
-                    "src/lib/jpeg/jcdctmgr.c",
-                    "src/lib/jpeg/jchuff.c",
-                    "src/lib/jpeg/jcinit.c",
-                    "src/lib/jpeg/jcmainct.c",
-                    "src/lib/jpeg/jcmarker.c",
-                    "src/lib/jpeg/jcmaster.c",
-                    "src/lib/jpeg/jcparam.c",
-                    "src/lib/jpeg/jcprepct.c",
-                    "src/lib/jpeg/jcsample.c",
-                    "src/lib/jpeg/jcarith.c",
-                    # LIB PNG:
-                    ##########
-                    "src/lib/png/png.c",
-                    "src/lib/png/pngset.c",
-                    "src/lib/png/pngget.c",
-                    "src/lib/png/pngtrans.c",
-                    "src/lib/png/pngmem.c",
-                    "src/lib/png/pngerror.c",
-                    "src/lib/png/pngread.c",
-                    "src/lib/png/pngwrite.c",
-                    "src/lib/png/pngwutil.c",
-                    "src/lib/png/pngwio.c",
-                    "src/lib/png/pngwtran.c",
-                    # ZLIB:
-                    #######
-                    "src/lib/zlib/adler32.c",
-                    "src/lib/zlib/crc32.c",
-                    "src/lib/zlib/gzlib.c",
-                    "src/lib/zlib/zutil.c",
-                    "src/lib/zlib/gzwrite.c",
-                    "src/lib/zlib/compress.c",
-                    "src/lib/zlib/deflate.c",
-                    "src/lib/zlib/trees.c",
-                    # LIB GIF:
-                    ##########
-                    "src/lib/gif/egif_lib.c",
-                    "src/lib/gif/gif_err.c",
-                    "src/lib/gif/gifalloc.c",
-                    "src/lib/gif/gif_hash.c",
-                    "src/lib/gif/quantize.c",
-                    "src/lib/gif/openbsd-reallocarray.c",
-                ],
-                'include_dirs': [
-                    'src/win',
-                    'src/lib/zlib',
-                    'src/lib/jpeg',
-                    'src/lib/png',
-                    'src/lib/gif',
-                ]
+                'include_dirs': ['src/win']
             }]
         ]
     },{


### PR DESCRIPTION
Not just on Windows machines.

The big change here is the reversion of 9caf18d from mixer/lwip#1. I'm not really convinced that it bought us too much of a time savings.

Building _everything_ from source allows us to use [`@randy.tarampi/lwip`](http://npmjs.com/package/@randy.tarampi/lwip) as a drop-in [`lwip`](http://npmjs.com/package/lwip) replacement, without having to do any other system setup or configuration. Ideally though, we'd build and release binaries as [`node-libpng`](http://npmjs.com/package/node-libpng) that get downloaded on `npm install`, but that's a bigger change.